### PR TITLE
Fix script duplicate injection

### DIFF
--- a/dapp/src/public/index.html
+++ b/dapp/src/public/index.html
@@ -7,6 +7,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="/bundle.js"></script>
   </body>
 </html>

--- a/dapp/webpack.config.ts
+++ b/dapp/webpack.config.ts
@@ -43,6 +43,7 @@ const config: Configuration = {
     new HtmlWebpackPlugin({
       template: "./src/public/index.html",
       favicon: "./src/public/favicon.svg",
+      inject: true,
     }),
     new ForkTsCheckerPlugin({
       typescript: {


### PR DESCRIPTION
Removes the script tag from the bundled HTML file since Webpack HTML plugin already injects the compiled bundle out of the box