### PR TITLE
Set correct root path for bundle script

### DIFF
--- a/dapp/webpack.config.ts
+++ b/dapp/webpack.config.ts
@@ -44,6 +44,7 @@ const config: Configuration = {
       template: "./src/public/index.html",
       favicon: "./src/public/favicon.svg",
       inject: true,
+      publicPath: "/",
     }),
     new ForkTsCheckerPlugin({
       typescript: {


### PR DESCRIPTION
Fixes the script public path so the dApp doesn't break when loading it from nested routes