### PR TITLE
Fix webpack dev server cors settings

### DIFF
--- a/dapp/webpack.config.ts
+++ b/dapp/webpack.config.ts
@@ -79,6 +79,12 @@ const config: Configuration = {
     static: {
       directory: path.join(__dirname, "public"),
     },
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "X-Requested-With, content-type, Authorization",
+    },
     historyApiFallback: true,
     compress: true,
     port: 9000,


### PR DESCRIPTION
Sets proper headers to avoid CORS issues during development

### Testing
- [ ] Check outgoing network requests to e.g. UNS are not throwing errors