### PR TITLE
Trigger first transaction signing on modal open

### DIFF
--- a/src/shared/components/Transactions/TransactionsModal.tsx
+++ b/src/shared/components/Transactions/TransactionsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react"
-import { TransactionProgressStatus } from "shared/types"
+import { isTransactionPending } from "shared/utils"
 import Modal from "../Modal"
 import TransactionProgress, {
   TransactionProgressProps,
@@ -28,10 +28,7 @@ export default function TransactionsModal({
   }, [isOpen, transactions, transactionInProgress])
 
   useEffect(() => {
-    if (
-      transactions.length &&
-      transactions[0].status === TransactionProgressStatus.Approving
-    )
+    if (isTransactionPending(transactions[0].status))
       setTransactionInProgress(true)
   }, [transactions])
 


### PR DESCRIPTION
Resolves https://github.com/tahowallet/dapp/issues/215

After staking or unstaking the first transaction is triggered immediately. If there are more transaction, they are not triggered automatically