### PR TITLE
Allow wallet connection with Taho wallet only

### DIFF
--- a/src/shared/utils/web3Onboard.ts
+++ b/src/shared/utils/web3Onboard.ts
@@ -4,18 +4,21 @@ import walletConnectModule from "@web3-onboard/walletconnect"
 import { init } from "@web3-onboard/react"
 import { ARBITRUM } from "shared/constants"
 
-const wallets = [
-  tahoWalletModule(),
-  trezorModule({
+const walletsSetup = {
+  taho: tahoWalletModule(),
+  trezor: trezorModule({
     // TODO: use proper email and url
     email: "doggos@taho.xyz",
     appUrl: "https://taho.xyz",
   }),
-  walletConnectModule({
+  walletConnect: walletConnectModule({
     projectId: process.env.WALLET_CONNECT_ID ?? "",
     requiredChains: [42161],
   }),
-]
+}
+
+const wallets = [walletsSetup.taho]
+
 const chains = [ARBITRUM]
 // TODO: decide what metadata should look like
 const appMetadata = {
@@ -30,7 +33,8 @@ const web3Onboard = init({
   appMetadata,
   connect: {
     autoConnectLastWallet: true,
-    removeIDontHaveAWalletInfoLink: true,
+    iDontHaveAWalletLink:
+      "https://chrome.google.com/webstore/detail/taho/eajafomhmkipbjmfmhebemolkcicgfmd",
     removeWhereIsMyWalletWarning: true,
   },
   accountCenter: {


### PR DESCRIPTION
Resolves #233

- hide other wallets from connection modal
- make sure there is a link to chrome store available

![image](https://github.com/tahowallet/dapp/assets/20949277/1b2965ea-301e-48a2-8f86-51c0b3f6db34)
