### PR TITLE
Improve icons distribution on population bar

### DIFF
--- a/src/redux-state/selectors/island.ts
+++ b/src/redux-state/selectors/island.ts
@@ -84,12 +84,6 @@ export const selectMaxPopulation = createSelector(
     realms.length ? Math.max(...realms.map((realm) => realm.population)) : 0
 )
 
-export const selectMinPopulation = createSelector(
-  selectSortedPopulation,
-  (realms) =>
-    realms.length ? Math.min(...realms.map((realm) => realm.population)) : 0
-)
-
 /* Helpful selectors */
 export const selectIsStakingRealmDisplayed = createSelector(
   selectStakingRealmAddress,

--- a/src/shared/utils/island.ts
+++ b/src/shared/utils/island.ts
@@ -162,7 +162,6 @@ const POPULATION_BAR_GAP = 8
 export function calculatePopulationIconsPositions(
   width: number,
   realmsData: RealmsData[],
-  minValue: number,
   maxValue: number
 ) {
   const positions: number[] = []
@@ -178,25 +177,24 @@ export function calculatePopulationIconsPositions(
     if (index === 0) {
       iconPosition = POPULATION_BAR_GAP
     }
+
     // Realm with biggest population
     if (realm.population === maxValue) {
       iconPosition = width - (POPULATION_BAR_GAP + POPULATION_ICON_SIZE)
     }
+
     // Realms have small population difference
     if (iconPosition < positions[index - 1] + POPULATION_ICON_SIZE) {
       iconPosition = positions[index - 1] + POPULATION_ICON_SIZE
     }
+
     // Setting max position for realms sorted by population
-    if (
-      iconPosition + POPULATION_ICON_SIZE >
+    const MAX_VALUE =
       width -
-        ((realmsData.length - index) * POPULATION_ICON_SIZE +
-          POPULATION_BAR_GAP)
-    ) {
-      iconPosition =
-        width -
-        (POPULATION_BAR_GAP +
-          (realmsData.length - index) * POPULATION_ICON_SIZE)
+      ((realmsData.length - index) * POPULATION_ICON_SIZE + POPULATION_BAR_GAP)
+
+    if (iconPosition + POPULATION_ICON_SIZE > width - MAX_VALUE) {
+      iconPosition = MAX_VALUE
     }
 
     positions[index] = iconPosition

--- a/src/ui/Footer/RealmBar/index.tsx
+++ b/src/ui/Footer/RealmBar/index.tsx
@@ -7,7 +7,6 @@ import {
   separateThousandsByComma,
 } from "shared/utils"
 import {
-  selectMinPopulation,
   selectMaxPopulation,
   selectSortedPopulation,
   selectTotalPopulation,
@@ -21,7 +20,6 @@ export default function RealmsBar() {
   const realmsData = useDappSelector(selectSortedPopulation)
   const totalPopulation = useDappSelector(selectTotalPopulation)
   const maxPopulation = useDappSelector(selectMaxPopulation)
-  const minPopulation = useDappSelector(selectMinPopulation)
 
   const [positions, setPositions] = useState<number[]>([])
   const progressBarRef = useRef<HTMLDivElement>(null)
@@ -36,12 +34,11 @@ export default function RealmsBar() {
     const pos = calculatePopulationIconsPositions(
       width,
       realmsData,
-      minPopulation,
       maxPopulation
     )
 
     setPositions(pos)
-  }, [realmsData, minPopulation, maxPopulation, progressBarRef])
+  }, [realmsData, maxPopulation, progressBarRef])
 
   return (
     <>


### PR DESCRIPTION
Resolves #281 

The icons on the population bar are now placed in this way:
- min value is shifted to the left
- max value is shifted to the right
- rest of the icons is distributed as a percentage of share  between minimum and maximum population