### PR TITLE
Rename button to `quick unstaking`

### DIFF
--- a/src/testing/components/TestingPanel.tsx
+++ b/src/testing/components/TestingPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { unlockStaking } from "testing/utils"
+import { setQuickUnstaking } from "testing/utils/quickUnstaking"
 
 /**
  * This component shouldn't be used in production.
@@ -12,8 +12,8 @@ export default function TestingPanel() {
 
   return (
     <div className="testing row">
-      <button type="button" onClick={unlockStaking}>
-        Unlock staking
+      <button type="button" onClick={setQuickUnstaking}>
+        Quick unstaking
       </button>
       <style jsx>
         {`

--- a/src/testing/utils/quickUnstaking.ts
+++ b/src/testing/utils/quickUnstaking.ts
@@ -17,7 +17,7 @@ const setBalance = (address: string, balance: string) =>
   localhostProvider.send("hardhat_setBalance", [address, balance])
 
 // eslint-disable-next-line import/prefer-default-export
-export async function unlockStaking() {
+export async function setQuickUnstaking() {
   await impersonate(TAHO_MULTISIG)
   await setBalance(TAHO_MULTISIG, "0x1000000000000")
 


### PR DESCRIPTION
Make the button name more descriptive to avoid confusing people during QA