### PR TITLE
Create reusable local storage hook

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ import reduxStore from "./redux-state"
 function DApp() {
   const islandMode = useDappSelector(selectIslandMode)
   const { isConnected } = useConnect()
-  const [isOnboarded] = useWalletOnboarding()
+  const { walletOnboarded } = useWalletOnboarding()
 
   useWallet()
   useGameDataFetch()
@@ -37,8 +37,8 @@ function DApp() {
     <>
       <GlobalStyles />
       <Router>
-        {(!isOnboarded || !isConnected) && <Onboarding />}
-        {isOnboarded && isConnected && (
+        {(!walletOnboarded || !isConnected) && <Onboarding />}
+        {walletOnboarded && isConnected && (
           <>
             <IslandComponent />
             <TestingPanel />

--- a/src/shared/hooks/assistant.ts
+++ b/src/shared/hooks/assistant.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react"
 import { LOCAL_STORAGE_ASSISTANT } from "shared/constants"
+import { useLocalStorageChange } from "./helpers"
 
 type AssistantType = "welcome" | "quests" | "default"
 
@@ -8,44 +8,18 @@ type Assistant = {
   visible: boolean
 }
 
-// Source: https://sabesh.hashnode.dev/update-components-based-on-localstorage-change-in-react-hooks
 // eslint-disable-next-line import/prefer-default-export
 export function useAssistant(): {
-  assistant: Assistant
+  assistant: Assistant | null
   updateAssistant: (newValue: Assistant) => void
   assistantVisible: (type: AssistantType) => boolean
 } {
-  const initialValue = localStorage.getItem(LOCAL_STORAGE_ASSISTANT) || null
-  const [assistant, setAssistant] = useState(
-    initialValue ? JSON.parse(initialValue) : null
+  const { value, updateStorage } = useLocalStorageChange<Assistant>(
+    LOCAL_STORAGE_ASSISTANT
   )
 
-  useEffect(() => {
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key !== LOCAL_STORAGE_ASSISTANT) return
-      setAssistant(e.newValue ? JSON.parse(e.newValue) : null)
-    }
+  const assistantVisible = (type: AssistantType): boolean =>
+    value ? value.visible && value.type === type : false
 
-    window.addEventListener("storage", handleStorageChange)
-    return () => window.removeEventListener("storage", handleStorageChange)
-  })
-
-  const updateAssistant = (newValue: Partial<Assistant>) => {
-    window.localStorage.setItem(
-      LOCAL_STORAGE_ASSISTANT,
-      JSON.stringify(newValue)
-    )
-
-    const event = new StorageEvent("storage", {
-      key: LOCAL_STORAGE_ASSISTANT,
-      newValue: JSON.stringify(newValue),
-    })
-
-    window.dispatchEvent(event)
-  }
-
-  const assistantVisible = (type: AssistantType) =>
-    assistant.visible && assistant.type === type
-
-  return { assistant, updateAssistant, assistantVisible }
+  return { assistant: value, updateAssistant: updateStorage, assistantVisible }
 }

--- a/src/shared/hooks/helpers.ts
+++ b/src/shared/hooks/helpers.ts
@@ -165,3 +165,37 @@ export function useAssets(assets: string[]) {
 
   return assetsLoaded
 }
+
+// Source: https://sabesh.hashnode.dev/update-components-based-on-localstorage-change-in-react-hooks
+export function useLocalStorageChange<T>(key: string): {
+  value: T | null
+  updateStorage: (newValue: Partial<T>) => void
+} {
+  const initialValue = localStorage.getItem(key) || null
+  const [value, setValue] = useState(
+    initialValue ? JSON.parse(initialValue) : null
+  )
+
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key !== key) return
+      setValue(e.newValue ? JSON.parse(e.newValue) : null)
+    }
+
+    window.addEventListener("storage", handleStorageChange)
+    return () => window.removeEventListener("storage", handleStorageChange)
+  })
+
+  const updateStorage = (newValue: Partial<T>) => {
+    window.localStorage.setItem(key, JSON.stringify(newValue))
+
+    const event = new StorageEvent("storage", {
+      key,
+      newValue: JSON.stringify(newValue),
+    })
+
+    window.dispatchEvent(event)
+  }
+
+  return { value, updateStorage }
+}

--- a/src/shared/hooks/wallets.ts
+++ b/src/shared/hooks/wallets.ts
@@ -1,5 +1,5 @@
 import { useConnectWallet } from "@web3-onboard/react"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo } from "react"
 import { ethers } from "ethers"
 import {
   useDappDispatch,
@@ -11,7 +11,7 @@ import {
   resetBalances,
 } from "redux-state"
 import { BALANCE_UPDATE_INTERVAL, LOCAL_STORAGE_WALLET } from "shared/constants"
-import { useInterval } from "./helpers"
+import { useInterval, useLocalStorageChange } from "./helpers"
 
 export function useArbitrumProvider(): ethers.providers.Web3Provider | null {
   const [{ wallet }] = useConnectWallet()
@@ -63,41 +63,19 @@ export function useWallet() {
   }, [address, arbitrumProvider, avatar, dispatch])
 }
 
-// Source: https://sabesh.hashnode.dev/update-components-based-on-localstorage-change-in-react-hooks
-export function useWalletOnboarding(): [
-  string | null,
-  (newValue: string) => void
-] {
-  const initialValue = localStorage.getItem(LOCAL_STORAGE_WALLET) || null
-  const [walletOnboarded, setWalletOnboarded] = useState(initialValue)
+export function useWalletOnboarding(): {
+  walletOnboarded: string | null
+  updateWalletOnboarding: (newValue: string) => void
+} {
+  const { value, updateStorage } =
+    useLocalStorageChange<string>(LOCAL_STORAGE_WALLET)
 
-  useEffect(() => {
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key !== LOCAL_STORAGE_WALLET) return
-      setWalletOnboarded(e.newValue)
-    }
-
-    window.addEventListener("storage", handleStorageChange)
-    return () => window.removeEventListener("storage", handleStorageChange)
-  })
-
-  const updateWalletOnboarding = (newValue: string) => {
-    window.localStorage.setItem(LOCAL_STORAGE_WALLET, newValue)
-
-    const event = new StorageEvent("storage", {
-      key: LOCAL_STORAGE_WALLET,
-      newValue,
-    })
-
-    window.dispatchEvent(event)
-  }
-
-  return [walletOnboarded, updateWalletOnboarding]
+  return { walletOnboarded: value, updateWalletOnboarding: updateStorage }
 }
 
 export function useConnect() {
   const [{ wallet }, connect, disconnect] = useConnectWallet()
-  const [_, updateWalletOnboarding] = useWalletOnboarding()
+  const { updateWalletOnboarding } = useWalletOnboarding()
 
   const disconnectBound = useCallback(() => {
     updateWalletOnboarding("")

--- a/src/ui/Onboarding/EnterPortal.tsx
+++ b/src/ui/Onboarding/EnterPortal.tsx
@@ -5,12 +5,12 @@ import { selectWalletAddress, useDappSelector } from "redux-state"
 
 export default function EnterPortal() {
   const walletAddress = useDappSelector(selectWalletAddress)
-  const [_, setIsOnboarded] = useWalletOnboarding()
+  const { updateWalletOnboarding } = useWalletOnboarding()
 
   return (
     <OnboardingModal
       buttonLabel="Enter the portal"
-      onClick={() => setIsOnboarded(walletAddress)}
+      onClick={() => updateWalletOnboarding(walletAddress)}
     >
       You have been
       <br /> granted passage.


### PR DESCRIPTION
Resolves #316 

Created reusable local storage hook since `useAssistant` and `useWalletOnboarding` hooks share the same logic