### PR TITLE
Tooltip zIndex issue fix

### DIFF
--- a/src/shared/components/Tooltip.tsx
+++ b/src/shared/components/Tooltip.tsx
@@ -82,6 +82,7 @@ export default function Tooltip({
           .tooltip {
             position: relative;
             margin-left: ${gap};
+            z-index: 50;
           }
           .tooltip_content {
             width: ${width};


### PR DESCRIPTION
<img width="560" alt="tooltip_zindex" src="https://github.com/tahowallet/dapp/assets/28560653/4aa1477e-35bd-47ad-b2e9-0b0b9475bcc7">
