### PR TITLE
Update copy on Realm Banner and Quest Assistant

### DIFF
--- a/src/ui/Assistant/AssistantContent/AssistantQuests.tsx
+++ b/src/ui/Assistant/AssistantContent/AssistantQuests.tsx
@@ -44,8 +44,9 @@ export default function AssistantQuests() {
         </div>
         <div className="paragraph row_center">
           <p>
-            You can see this week&apos;s Quests under the <span>Quest Bar</span>
-            . You&apos;ll be able to redeem XP in the future for rewards.
+            You can see this week&apos;s Quests under the{" "}
+            <span>Quests bar</span>. You&apos;ll be able to redeem XP in the
+            future for rewards.
           </p>
         </div>
       </AssistantContent>

--- a/src/ui/Island/RealmDetails/RealmBanners/BannerRewards.tsx
+++ b/src/ui/Island/RealmDetails/RealmBanners/BannerRewards.tsx
@@ -73,17 +73,20 @@ export default function BannerRewards({ amount }: { amount: number }) {
           <div className="row_center">
             Claimable rewards
             <Tooltip>
-              You don&apos;t have to claim your XP until end of season. Unless
-              you plan on trading it.
+              {/* TODO: Change after beta to:
+              You don&apos;t have to claim your XP until end of season, unless
+              you plan on trading it. */}
+              You don&apos;t have to claim your XP until end of season.
+              {/* TODO: Uncomment after beta:
               <br />
               Exchanging XP for $TAHO only happens at the end of seasons.
-              <br />
+              <br /> */}
               <a
                 href="/"
                 target="_blank"
                 style={{ textDecoration: "underline" }}
               >
-                Read more here
+                Read more here.
               </a>
             </Tooltip>
           </div>


### PR DESCRIPTION
Some copy is not relevant in beta, we're removing it for now. We're also improving wording in couple of places.