### PR TITLE
Update `README` describing how to choose which RPC will be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 
 ## Installation
 
-1.  Create a `.env` file in the root directory of the project and provide values for the following variables:
-    ```bash
-    WALLET_CONNECT_ID=""
-    UNS_API_KEY=""
-    FILE_DIRECTORY_IPFS_HASH=""
-    PART_GLOSSARY_IPFS_HASH=""
-    ```
+1.  Decide which RPC from the `.env.defaults` to use and create an `.env` file
+    in the root directory with one of the following variables set to `true`:
+    `USE_LOCALHOST_FORK` / `USE_TENDERLY_FORK` / `USE_ARBITRUM_SEPOLIA`.
 2.  Install dependencies and start the app.
     ```bash
     yarn install


### PR DESCRIPTION
A person installing the Dapp does not need to set
```
    WALLET_CONNECT_ID=""
    UNS_API_KEY=""
    FILE_DIRECTORY_IPFS_HASH=""
    PART_GLOSSARY_IPFS_HASH=""
```
as they are already set in `.env.defaults`. Instead users need to decide which RPC should be used when building the environment.