### PR TITLE
Display amounts and counters in localized format

### DIFF
--- a/src/shared/components/RealmModal/RealmHeader.tsx
+++ b/src/shared/components/RealmModal/RealmHeader.tsx
@@ -13,6 +13,7 @@ import {
   selectRealmById,
   useDappSelector,
 } from "redux-state"
+import { separateThousandsByComma } from "shared/utils"
 
 export default function RealmHeader() {
   const realmId = useDappSelector(selectDisplayedRealmId)
@@ -42,7 +43,7 @@ export default function RealmHeader() {
               />
               Population
             </span>
-            <span>{realm?.population}</span>
+            <span>{separateThousandsByComma(realm?.population ?? 0)}</span>
           </div>
           <div className="tag column">
             <span

--- a/src/shared/components/TokenAmountInput.tsx
+++ b/src/shared/components/TokenAmountInput.tsx
@@ -1,5 +1,9 @@
 import React from "react"
-import { bigIntToUserAmount, userAmountToBigInt } from "shared/utils"
+import {
+  bigIntToUserAmount,
+  userAmountToBigInt,
+  separateThousandsByComma,
+} from "shared/utils"
 import {
   selectTokenBalanceByAddress,
   selectTokenSymbolByAddress,
@@ -68,7 +72,9 @@ export default function TokenAmountInput({
   return (
     <div>
       {label && (
-        <div className="label">{`${label} ${maxAmount} ${symbol}`}</div>
+        <div className="label">{`${label} ${separateThousandsByComma(
+          maxAmount
+        )} ${symbol}`}</div>
       )}
       <SharedInput
         type="number"

--- a/src/shared/utils/numbers.ts
+++ b/src/shared/utils/numbers.ts
@@ -1,3 +1,7 @@
 // eslint-disable-next-line import/prefer-default-export
-export const separateThousandsByComma = (value: number | bigint): string =>
-  value.toLocaleString("en-US", { maximumFractionDigits: 2 })
+export const separateThousandsByComma = (
+  value: number | bigint | string
+): string => {
+  const adjustedValue = typeof value === "string" ? +value : value
+  return adjustedValue.toLocaleString("en-US", { maximumFractionDigits: 2 })
+}

--- a/src/ui/Island/RealmDetails/Quests/QuestsDetails.tsx
+++ b/src/ui/Island/RealmDetails/Quests/QuestsDetails.tsx
@@ -9,7 +9,11 @@ import {
   useDappSelector,
 } from "redux-state"
 import RealmIcon from "shared/components/RealmIcon"
-import { bigIntToUserAmount, formatDate } from "shared/utils"
+import {
+  bigIntToUserAmount,
+  formatDate,
+  separateThousandsByComma,
+} from "shared/utils"
 
 export default function QuestsDetails({
   realmId,
@@ -56,7 +60,9 @@ export default function QuestsDetails({
               width="32px"
               color="var(--primary-p1-100)"
             />
-            {bigIntToUserAmount(realm?.xpAllocatable ?? 0n)}
+            {separateThousandsByComma(
+              bigIntToUserAmount(realm?.xpAllocatable ?? 0n)
+            )}
           </h1>
           {tokenSymbol}
         </div>

--- a/src/ui/Island/RealmDetails/RealmBanners/BannerRewards.tsx
+++ b/src/ui/Island/RealmDetails/RealmBanners/BannerRewards.tsx
@@ -15,6 +15,7 @@ import ClaimCongratulations from "ui/Claim/modals/ClaimCongratulations"
 import Tooltip from "shared/components/Tooltip"
 import { useTransactionSuccessCallback } from "shared/hooks"
 import TransactionsModal from "shared/components/Transactions/TransactionsModal"
+import { separateThousandsByComma } from "shared/utils"
 
 const CLAIM_XP_TX_ID = "claim-xp"
 
@@ -110,7 +111,9 @@ export default function BannerRewards({ amount }: { amount: number }) {
               width="32px"
               color="var(--primary-p1-100)"
             />
-            <div className="token_amount">{amount}</div>
+            <div className="token_amount">
+              {separateThousandsByComma(amount)}
+            </div>
             <div className="token_name">{realm.xpToken.symbol}</div>
           </div>
         </div>


### PR DESCRIPTION
Resolves #375 

The `separateThousandsByComma` utility function was adjusted. Displaying of the amounts is consistent now.

If there are any places that are still missing this adjustment, please write it down.