### PR TITLE
Population count on the Quest Assistant shows wrong value

### DIFF
--- a/src/ui/Assistant/AssistantContent/AssistantQuests.tsx
+++ b/src/ui/Assistant/AssistantContent/AssistantQuests.tsx
@@ -26,7 +26,12 @@ export default function AssistantQuests() {
           here!
         </div>
         <div style={{ height: 40 }}>
-          {realm && <p>Population of {realm.population - 1} + 1 (You!)</p>}
+          {realm && (
+            <p>
+              Population of {realm.population > 0 ? realm.population - 1 : 0} +
+              1 (You!)
+            </p>
+          )}
         </div>
         <div className="hint row">
           <Icon


### PR DESCRIPTION
Resolves #360 

<img width="353" alt="360" src="https://github.com/tahowallet/dapp/assets/28560653/4bb462da-af78-4977-9c09-018bc622bd2c">
