### PR TITLE
Fixed an issue about connecting wallets

### DIFF
--- a/patches/@web3-onboard+taho+2.0.5.patch
+++ b/patches/@web3-onboard+taho+2.0.5.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/@web3-onboard/taho/dist/index.js b/node_modules/@web3-onboard/taho/dist/index.js
+index e2e3b4b..3706a5c 100644
+--- a/node_modules/@web3-onboard/taho/dist/index.js
++++ b/node_modules/@web3-onboard/taho/dist/index.js
+@@ -13,8 +13,11 @@ function tahoWallet() {
+             },
+             getIcon: async () => (await import('./icon.js')).default,
+             getInterface: async () => {
+-                const provider = await detectEthereumProvider({ mustBeTallyHo: true });
+-                if (!provider) {
++                // When Taho isn't the default wallet and MetaMask is installed we are unable to connect to the dapp.
++                // Let's force a connection to the Taho wallet and
++                // make sure the user receives the correct message when Taho isn't installed.
++                const provider = await detectEthereumProvider();
++                if (!provider || window.tally === undefined) {
+                     const onboarding = new TallyHoOnboarding();
+                     onboarding.startOnboarding();
+                     throw new Error('Please install Taho to use this wallet');


### PR DESCRIPTION
Closes https://github.com/tahowallet/dapp/issues/381


### What

There is a issue related to incorrect handling of the Taho wallet in the `@web3-onboard/taho` library. Let's fix this with a patch file. The solution is still not ideal because it does not catch the change of which wallet is switched on. This means that when we install the Taho wallet we have to refresh the page to see that the wallet has been installed. I think this solution is enough at the moment. Let's solve this problem in https://github.com/tahowallet/dapp/issues/423.


### Testing

**When MetaMask is installed**

- [ ]  Try connecting when the wallet is the default
- [ ]  Try connecting when the wallet is not the default

**When MetaMask is'n installed**

- [ ] Try connecting when the wallet is the default
- [ ] Try connecting when the wallet is not the default

**When Taho isn't installed but MetaMask it is**

- [ ] There is no connection possible. The user receives the correct message.