### PR TITLE
Set correct chain for wallet

### DIFF
--- a/src/shared/hooks/wallets.ts
+++ b/src/shared/hooks/wallets.ts
@@ -116,6 +116,21 @@ export function useConnect() {
   const [{ wallet }, connect, disconnect] = useConnectWallet()
   const { updateWalletOnboarding } = useWalletOnboarding()
 
+  useEffect(() => {
+    if (wallet?.provider !== undefined) {
+      const setCorrectChain = async () => {
+        const walletProvider = new ethers.providers.Web3Provider(
+          wallet.provider
+        )
+        await walletProvider.send("wallet_switchEthereumChain", [
+          { chainId: ARBITRUM.id },
+        ])
+      }
+
+      setCorrectChain()
+    }
+  }, [wallet?.provider])
+
   const disconnectBound = useCallback(() => {
     updateWalletOnboarding("")
     return wallet && disconnect(wallet)


### PR DESCRIPTION
Closes https://github.com/tahowallet/dapp/issues/343

The `web3Onboard` library does not switch the network properly for us. Let's fix it using method `wallet_switchEthereumChain`. Check that the transactions sent are on the correct chain and that the wallet has the correct data set up for the dapp.

![Screenshot 2023-10-19 at 11 56 49](https://github.com/tahowallet/dapp/assets/23117945/1ecc0ac2-da5e-46fa-9a19-a015241b930d)

<img width="250" alt="Screenshot 2023-10-19 at 12 04 24" src="https://github.com/tahowallet/dapp/assets/23117945/95487253-fb1b-4cab-ad5d-d203a1b6d347">
