### PR TITLE
Sync `stage-live` to `stage-fork`

### DIFF
--- a/.github/workflows/update-environments.yml
+++ b/.github/workflows/update-environments.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Open/update a PR from `main` to `stage-live`
         id: pr
-        uses: tretuna/sync-branches@1.4.0
+        uses: tretuna/sync-branches@ea58ab6 # 1.4.0
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "main"
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Open/update a PR from `main` to `stage-live`
         id: pr
-        uses: tretuna/sync-branches@1.4.0
+        uses: tretuna/sync-branches@ea58ab6 # 1.4.0
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "stage-live"


### PR DESCRIPTION
We want to keep the state of `stage-fork` branch the same as the state of `stage-fork` branch. To achieve that we've added a CI job that triggers on each push to `stage-live` and pushes the new `stage-live` changes to `stage-fork`.