### PR TITLE
Round the `xpAllocatable` number

### DIFF
--- a/src/ui/Island/RealmDetails/Quests/QuestsDetails.tsx
+++ b/src/ui/Island/RealmDetails/Quests/QuestsDetails.tsx
@@ -56,7 +56,9 @@ export default function QuestsDetails({
               width="32px"
               color="var(--primary-p1-100)"
             />
-            {separateThousandsByComma(realm?.xpAllocatable ?? "0")}
+            {separateThousandsByComma(
+              Math.round(parseFloat(realm?.xpAllocatable ?? "0"))
+            )}
           </h1>
           {tokenSymbol}
         </div>


### PR DESCRIPTION
Let's fix the `xpAllocatable` number in the UI by rounding up allocated taho.

**Before**
<img width="682" alt="Screenshot 2023-10-23 at 15 38 26" src="https://github.com/tahowallet/dapp/assets/23117945/86f111d6-5f93-4bf9-bf7f-b8d9aada78d5">


**After**
<img width="700" alt="Screenshot 2023-10-23 at 15 38 52" src="https://github.com/tahowallet/dapp/assets/23117945/c75093ec-6390-4fd9-a376-deb620a825cc">
