### PR TITLE
Fix conditions for running job adding the testlist

### DIFF
--- a/.github/workflows/test-list.yml
+++ b/.github/workflows/test-list.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   add-release-test-list:
     runs-on: ubuntu-latest
-    if: github.head_ref == 'refs/heads/stage-live'
+    if: github.head_ref == 'stage-live'
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
The `github.head_ref` variable does not include the `ref/heads/` part.