### PR TITLE
Fix for posthog

### DIFF
--- a/src/redux-state/selectors/island.ts
+++ b/src/redux-state/selectors/island.ts
@@ -20,6 +20,11 @@ export const selectRealmById = createSelector(
   (realms, realmId) => (realmId ? realms[realmId] : null)
 )
 
+export const selectRealmNameById = createSelector(
+  [selectRealms, (_, realmId: string | null) => realmId],
+  (realms, realmId) => (realmId ? realms[realmId].name : null)
+)
+
 export const selectRealmWithIdByAddress = createSelector(
   [selectRealms, (_, realmAddress: string) => realmAddress],
   (realms, realmAddress) =>

--- a/src/ui/Island/RealmDetails/StakingForms/StakeForm.tsx
+++ b/src/ui/Island/RealmDetails/StakingForms/StakeForm.tsx
@@ -10,6 +10,7 @@ import {
   stopTrackingTransactionStatus,
   selectStakingRealmAddress,
   selectStakingRealmId,
+  selectRealmNameById,
 } from "redux-state"
 import { isValidInputAmount, userAmountToBigInt } from "shared/utils"
 import classNames from "classnames"
@@ -31,6 +32,9 @@ export default function StakeForm({ isDisabled }: { isDisabled: boolean }) {
   const displayedRealmAddress = useDappSelector(selectDisplayedRealmAddress)
   const stakingRealmAddress = useDappSelector(selectStakingRealmAddress)
   const stakingRealmId = useDappSelector(selectStakingRealmId)
+  const realmName = useDappSelector((state) =>
+    selectRealmNameById(state, stakingRealmId)
+  )
 
   const [stakeAmount, setStakeAmount] = useState("")
   const [isStakeAmountValid, setIsStakeAmountValid] = useState(false)
@@ -60,7 +64,7 @@ export default function StakeForm({ isDisabled }: { isDisabled: boolean }) {
         })
       )
       posthog?.capture("Realm stake started", {
-        realmId: displayedRealmAddress,
+        realmName,
       })
     }
   }
@@ -81,7 +85,7 @@ export default function StakeForm({ isDisabled }: { isDisabled: boolean }) {
 
   const stakeTransactionSuccessCallback = useCallback(() => {
     posthog?.capture("Realm stake completed", {
-      realmId: displayedRealmAddress,
+      realmName,
     })
 
     setIsStakeTransactionModalOpen(false)
@@ -90,13 +94,7 @@ export default function StakeForm({ isDisabled }: { isDisabled: boolean }) {
     if (!stakingRealmId) {
       updateAssistant({ visible: true, type: "quests" })
     }
-  }, [
-    dispatch,
-    posthog,
-    displayedRealmAddress,
-    stakingRealmId,
-    updateAssistant,
-  ])
+  }, [posthog, realmName, dispatch, stakingRealmId, updateAssistant])
 
   const onInputChange = (value: string) => {
     setStakeAmount(value)

--- a/src/ui/Island/RealmDetails/StakingForms/UnstakeForm.tsx
+++ b/src/ui/Island/RealmDetails/StakingForms/UnstakeForm.tsx
@@ -11,6 +11,7 @@ import {
   selectTransactionStatusById,
   stopTrackingTransactionStatus,
   selectTokenBalanceByAddress,
+  selectRealmNameById,
 } from "redux-state"
 import { isValidInputAmount, userAmountToBigInt } from "shared/utils"
 import classNames from "classnames"
@@ -38,6 +39,9 @@ export default function UnstakeForm({ isDisabled }: { isDisabled: boolean }) {
     selectDisplayedRealmVeTokenAddress
   )
   const displayedRealmId = useDappSelector(selectDisplayedRealmId)
+  const realmName = useDappSelector((state) =>
+    selectRealmNameById(state, displayedRealmId)
+  )
 
   const veTahoBalance = useDappSelector((state) =>
     selectTokenBalanceByAddress(state, displayedRealmVeTokenAddress)
@@ -74,7 +78,7 @@ export default function UnstakeForm({ isDisabled }: { isDisabled: boolean }) {
       )
     }
     posthog?.capture("Realm unstake started", {
-      realmId: displayedRealmAddress,
+      realmName,
     })
   }
 
@@ -88,7 +92,7 @@ export default function UnstakeForm({ isDisabled }: { isDisabled: boolean }) {
 
   const unstakeTransactionSuccessCallback = useCallback(() => {
     posthog?.capture("Realm unstake completed", {
-      realmId: displayedRealmAddress,
+      realmName,
     })
 
     setIsUnstakeTransactionModalOpen(false)
@@ -96,7 +100,7 @@ export default function UnstakeForm({ isDisabled }: { isDisabled: boolean }) {
     setUnstakeAmount("")
     dispatch(stopTrackingTransactionStatus(UNSTAKE_TX_ID))
     updateAssistant({ visible: false, type: "default" })
-  }, [dispatch, displayedRealmAddress, posthog, updateAssistant])
+  }, [dispatch, realmName, posthog, updateAssistant])
 
   useTransactionSuccessCallback(
     unstakeTransactionStatus,

--- a/src/ui/Island/index.tsx
+++ b/src/ui/Island/index.tsx
@@ -1,5 +1,8 @@
 import React, { memo, useCallback, useEffect, useState } from "react"
-import { selectIsDefaultIslandMode } from "redux-state/selectors/island"
+import {
+  selectIsDefaultIslandMode,
+  selectRealmNameById,
+} from "redux-state/selectors/island"
 import RealmModal from "shared/components/RealmModal"
 import backgroundImg from "public/dapp_island_bg.webp"
 import {
@@ -25,6 +28,9 @@ import Quests from "./RealmDetails/Quests"
 function IslandWrapper() {
   const assetsLoaded = useAssets([backgroundImg])
   const [realmId, setRealmId] = useState<null | string>(null)
+  const realmName = useDappSelector((state) =>
+    selectRealmNameById(state, realmId)
+  )
 
   const dispatch = useDappDispatch()
 
@@ -33,10 +39,10 @@ function IslandWrapper() {
   const posthog = usePostHog()
 
   useEffect(() => {
-    if (realmId) {
-      posthog?.capture("Realm opened", { realmId })
+    if (realmName) {
+      posthog?.capture("Realm opened", { realmName })
     }
-  }, [posthog, realmId])
+  }, [posthog, realmName])
 
   useEffect(() => {
     dispatch(setDisplayedRealmId(realmId))


### PR DESCRIPTION
Closes https://github.com/tahowallet/dapp/issues/569

### What

- Don't send an event when the realm modal is closed.
- Use realm name for events



> “Realm open” seems to be sending a null realm id most of the time.
How might we normalize realm open's id and realm stake/unstake's? Right now one is address and the other is I assume the map node id. Normalizing to realm address might be most straightforward. At first blush I'd want to do name, but names can change in the long run—doesn't really matter for the beta though, so if this is easy let's do that.
Why might we be overcounting stake completed events? Right now these seem to be ~30% higher than the actual staked count, even if we subtract the few unstakes. Is it possible we're not overcounting/that we're counting a stake as complete from a PostHog perspective when it didn't actually go through?

We are currently tracking every stake transaction. When a user joins a realm, can stake more times for this realm. Therefore, the number of stake transactions is greater than the population.
