### PR TITLE
Switch to `pull_request_target` trigger in workflow adding test list

### DIFF
--- a/.github/workflows/test-list.yml
+++ b/.github/workflows/test-list.yml
@@ -6,7 +6,7 @@
 name: Add test list to release PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
     branches:


### PR DESCRIPTION
Despite having configured the workflow to trigger when a PR with base branch `release` and head branch `stage-live` is opened, we didn't see the workflow to trigger in those circumstances. We've tested similar config in other repository and it was working there. The difference was that in the other repository the PR opened wasn't showing warning about the branch being out-of-date (and in case of the release PRs in `dapp` we see that warning). So it looks that this may affect workflow triggering.
In this PR we want to verify if changing the triggering event to [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) will help. This event runs in the context of the base of the pull request, not in the context of the merge commit.