### PR TITLE
Display real xp allocatable in the realm modal

### DIFF
--- a/src/ui/Island/RealmDetails/Quests/QuestsDetails.tsx
+++ b/src/ui/Island/RealmDetails/Quests/QuestsDetails.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect } from "react"
 import {
   selectIsEndOfSeason,
   selectRealmById,
@@ -57,7 +57,7 @@ export default function QuestsDetails({
               width="32px"
               color="var(--primary-p1-100)"
             />
-            {separateThousandsByComma(realm?.xpAllocatable ?? WEEKLY_XP_ALLOCATION)}
+            {separateThousandsByComma(realm?.xpAllocatable || WEEKLY_XP_ALLOCATION)}
           </h1>
           {tokenSymbol}
         </div>


### PR DESCRIPTION
Resolves #634 

<img width="702" alt="634" src="https://github.com/tahowallet/dapp/assets/28560653/d799d089-8a49-4eeb-bf70-ba1f1ddb8531">
