### PR TITLE
Add support for Alchemy RPC

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -4,6 +4,7 @@ UNS_API_KEY="4a77c949-511b-4c16-9862-6edfb6ae6012"
 FILE_DIRECTORY_IPFS_HASH="QmYwYkRdYMBCtMqbimgaXjf7UL4RUb5zBQu4TDE67oZbq5"
 PART_GLOSSARY_IPFS_HASH="bafybeibytsozn7qsvqgecogv5urg5en34r7v3zxo326vacumi56ckah5b4"
 # RPC URLs
+ARBITRUM_SEPOLIA_ALCHEMY_KEY=""
 ARBITRUM_RPC_URL="https://sepolia-rollup.arbitrum.io/rpc"
 ARBITRUM_RPC_FALLBACK_URL="https://arbitrum-sepolia.blockpi.network/v1/rpc/public"
 TENDERLY_RPC_URL="https://rpc.tenderly.co/fork/2fc2cf12-5c58-439f-9b5e-967bfd02191a"

--- a/src/shared/constants/chains.ts
+++ b/src/shared/constants/chains.ts
@@ -19,6 +19,9 @@ export const getArbitrumRpcUrl = () => {
   }
 
   if (process.env.USE_ARBITRUM_SEPOLIA === "true") {
+    if (process.env.ARBITRUM_SEPOLIA_ALCHEMY_KEY) {
+      return `https://arb-sepolia.g.alchemy.com/v2/${process.env.ARBITRUM_SEPOLIA_ALCHEMY_KEY}`
+    }
     return process.env.ARBITRUM_RPC_URL
   }
 


### PR DESCRIPTION
Resolves https://github.com/tahowallet/dapp/issues/653

### What

Add Alchemy RPC as a main RPC for the dapp if API key is available.
When there is no key we fallback to the public RPC endpoint.

Netlify setup - Alchemy will be supported on:
- production
- stage-live