### PR TITLE
Fix "max" button for balances above 999

### DIFF
--- a/src/shared/components/TokenAmountInput.tsx
+++ b/src/shared/components/TokenAmountInput.tsx
@@ -1,5 +1,9 @@
 import React from "react"
-import { userAmountToBigInt, bigIntToDisplayUserAmount } from "shared/utils"
+import {
+  userAmountToBigInt,
+  bigIntToDisplayUserAmount,
+  bigIntToUserAmount,
+} from "shared/utils"
 import {
   selectTokenBalanceByAddress,
   selectTokenSymbolByAddress,
@@ -55,8 +59,6 @@ export default function TokenAmountInput({
     selectTokenSymbolByAddress(state, tokenAddress)
   )
 
-  const maxAmount = bigIntToDisplayUserAmount(balance)
-
   const validate = (value: string) => {
     const result = handleValidate(value, balance)
     const hasError = "error" in result
@@ -68,7 +70,9 @@ export default function TokenAmountInput({
   return (
     <div>
       {label && (
-        <div className="label">{`${label} ${maxAmount} ${symbol}`}</div>
+        <div className="label">{`${label} ${bigIntToDisplayUserAmount(
+          balance
+        )} ${symbol}`}</div>
       )}
       <SharedInput
         type="number"
@@ -84,7 +88,7 @@ export default function TokenAmountInput({
             isDisabled={disabled}
             onMouseDown={(event) => {
               event.preventDefault()
-              onChange(maxAmount)
+              onChange(bigIntToUserAmount(balance))
             }}
           >
             Max


### PR DESCRIPTION
### What
Don't try to parse strings with comma separated thousands as numbers.

### Testing

Find account with more than 999 TAHO/veTAHO balance and try to stake/unstake all by clicking on "Max" button.

Before: nothing happened, no value was displayed in the input
After: value is displayed in the input

![image](https://github.com/tahowallet/dapp/assets/20949277/fa684f18-7323-4227-909b-05e5009a7f69)
