### PR TITLE
Fix max button precision by passing correct arguments

### DIFF
--- a/src/shared/components/TokenAmountInput.tsx
+++ b/src/shared/components/TokenAmountInput.tsx
@@ -71,7 +71,9 @@ export default function TokenAmountInput({
     <div>
       {label && (
         <div className="label">{`${label} ${bigIntToDisplayUserAmount(
-          balance
+          balance,
+          18,
+          5
         )} ${symbol}`}</div>
       )}
       <SharedInput
@@ -88,7 +90,7 @@ export default function TokenAmountInput({
             isDisabled={disabled}
             onMouseDown={(event) => {
               event.preventDefault()
-              onChange(bigIntToUserAmount(balance))
+              onChange(bigIntToUserAmount(balance, 18, 18))
             }}
           >
             Max

--- a/src/shared/utils/numbers.ts
+++ b/src/shared/utils/numbers.ts
@@ -4,10 +4,15 @@ import { FixedPointNumber } from "shared/types/stake"
 const FLOATING_POINT_REGEX = /^[^0-9]*([0-9,]+)(?:\.([0-9]*))?$/
 
 export const separateThousandsByComma = (
-  value: number | bigint | string
+  value: number | bigint | string,
+  decimals = 2
 ): string => {
   const adjustedValue = typeof value === "string" ? +value : value
-  return adjustedValue.toLocaleString("en-US", { maximumFractionDigits: 2 })
+  return adjustedValue.toLocaleString("en-US", {
+    // @ts-expect-error - `maximumFractionDigits` wants to get number less than 21,
+    // but as the tokens have 18 decimals have, we can safely pass a parameter
+    maximumFractionDigits: decimals < 21 ? decimals : 2,
+  })
 }
 
 function parseToFixedPointNumber(
@@ -81,7 +86,7 @@ export function bigIntToUserAmount(
   desiredDecimals = 2
 ): string {
   const desiredDecimalsAmount =
-    amount / 10n ** BigInt(Math.max(1, decimals - desiredDecimals))
+    amount / 10n ** BigInt(Math.max(0, decimals - desiredDecimals))
 
   return (
     Number(desiredDecimalsAmount) /
@@ -98,6 +103,7 @@ export function bigIntToDisplayUserAmount(
   const amountBigInt = typeof amount === "string" ? BigInt(amount) : amount
 
   return separateThousandsByComma(
-    bigIntToUserAmount(amountBigInt, decimals, desiredDecimals)
+    bigIntToUserAmount(amountBigInt, decimals, desiredDecimals),
+    desiredDecimals
   )
 }


### PR DESCRIPTION
Resolves: https://github.com/tahowallet/dapp/issues/688

### What

- Make it possible to stake/unstake amounts less than `0.01 TAHO`
- Make "max" button pass the numbers with full precision
- DIsplay small amounts in the stake/unstake headers

![image](https://github.com/tahowallet/dapp/assets/20949277/4ae1d2fb-3310-4613-897d-7d8373c998d3)
