### PR TITLE
Use `thesis-valkyrie` user's acces token to create release PR

### DIFF
--- a/.github/workflows/update-environments.yml
+++ b/.github/workflows/update-environments.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          # Needed so that we could create PR with `THESIS-VALKYRIE_PAT`,
+          # Needed so that we could create PR with `THESIS_VALKYRIE_PAT`,
           # otherwise it doesn't trigger `test-list.yml`.
           persist-credentials: false
       - name: Open/update a PR from `main` to `stage-live`
@@ -68,7 +68,7 @@ jobs:
           # token are not triggering other workflows (and we want trigger the
           # `test-list.yml` workflow after `sync-stage-live-to-release` creates
           # a PR).
-          GITHUB_TOKEN: ${{secrets.THESIS-VALKYRIE_PAT}}
+          GITHUB_TOKEN: ${{secrets.THESIS_VALKYRIE_PAT}}
           FROM_BRANCH: "stage-live"
           TO_BRANCH: "release"
           PULL_REQUEST_TITLE: "🚀 [QA] Update release environment"

--- a/.github/workflows/update-environments.yml
+++ b/.github/workflows/update-environments.yml
@@ -56,11 +56,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # Needed so that we could create PR with `THESIS-VALKYRIE_PAT`,
+          # otherwise it doesn't trigger `test-list.yml`.
+          persist-credentials: false
       - name: Open/update a PR from `main` to `stage-live`
         id: pr
         uses: tretuna/sync-branches@ea58ab6e406fd3ad016a064b31270bbb41127f41 # 1.4.0
         with:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # We couldn't use GITHUB_TOKEN here, because events triggered by this
+          # token are not triggering other workflows (and we want trigger the
+          # `test-list.yml` workflow after `sync-stage-live-to-release` creates
+          # a PR).
+          GITHUB_TOKEN: ${{secrets.THESIS-VALKYRIE_PAT}}
           FROM_BRANCH: "stage-live"
           TO_BRANCH: "release"
           PULL_REQUEST_TITLE: "🚀 [QA] Update release environment"


### PR DESCRIPTION
We had issues with triggering the `test-list.yml` workflow. It turned out this was because GitHub prevents from triggering workflows by events triggered by the `GITHUB_TOKEN` (and this was our case). To work around that we need to change the token used for creating the release PRs to a different one that `GITHUB_TOKEN` (we've decided to use a personal access token of the `thesis-valkyrie` user). We also needed to set `persist-credentials` parameter to `false` in `actions/checkout@v3` action in order to not save the auth token to the git config (thanks to this we'll be able to create PR with the specified PAT and trigger `test-list.yml` automatically after that event).

TODO:

- [x] Configure personal access token for the `thesis-valkyrie` GH account and set it's value under the `THESIS_VALKYRIE_PAT` secret accessible by the `dapp` repository. The PAT should have `repo` scope. (@Shadowfiend)

Useful links:
* [Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
* [Creating fine grained PATs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
* [Switching off credentials persistency](https://github.com/orgs/community/discussions/26220#discussioncomment-3250853)