### PR TITLE
Hide missing realm icon on Reflect cursor

### DIFF
--- a/src/ui/Island/Cursor/CursorLabel.tsx
+++ b/src/ui/Island/Cursor/CursorLabel.tsx
@@ -18,6 +18,7 @@ export default function CursorLabel({
 
   const { name, realmName, stakingRealmColor, cursorTextColor } = userInfo
   const iconKey = realmName?.toLowerCase() as keyof typeof REALM_ICONS
+  const iconSrc = REALM_ICONS[iconKey]
 
   return (
     <>
@@ -34,13 +35,8 @@ export default function CursorLabel({
         >
           {name}
         </div>
-        {realmName && (
-          <Icon
-            src={REALM_ICONS[iconKey]}
-            type="image"
-            height="16px"
-            width="16px"
-          />
+        {realmName && iconSrc && (
+          <Icon src={iconSrc} type="image" height="16px" width="16px" />
         )}
       </div>
       <style jsx>{`


### PR DESCRIPTION
If cursor has no realm image let's hide the icon.

Before 
![image](https://github.com/tahowallet/dapp/assets/20949277/2bb61250-d966-4b61-963e-20f8ce35f17a)
After 
![image](https://github.com/tahowallet/dapp/assets/20949277/3835d8bc-2997-4542-95c1-d71ee876730f)
