### PR TITLE
Add ellipsis for very long user names on the cursors

### DIFF
--- a/src/ui/Island/Cursor/CursorLabel.tsx
+++ b/src/ui/Island/Cursor/CursorLabel.tsx
@@ -30,8 +30,8 @@ export default function CursorLabel({
         }}
       >
         <div
-          className="elipsis"
-          style={{ whiteSpace: "nowrap", fontSize: "16px" }}
+          className="ellipsis"
+          style={{ whiteSpace: "nowrap", fontSize: "16px", maxWidth: "250px" }}
         >
           {name}
         </div>


### PR DESCRIPTION
Users with very long names should not see their whole name on the cursor to improve UX. 