### PR TITLE
Realm panel fix

### DIFF
--- a/src/shared/constants/realms.ts
+++ b/src/shared/constants/realms.ts
@@ -144,7 +144,7 @@ export const REALM_FONT_SIZE = 78
 export const REALM_FONT_FAMILY = "QuincyCF"
 export const REALM_FONT_STYLE = "bold"
 export const REALM_IMAGE_SIZE = 70
-export const REALM_PANEL_ANIMATION_TIME = 600
+export const REALM_PANEL_ANIMATION_TIME = 400
 
 export const REALM_ICONS = {
   arbitrum,

--- a/src/ui/Island/index.tsx
+++ b/src/ui/Island/index.tsx
@@ -42,16 +42,19 @@ function IslandWrapper() {
 
   const contextRef = useValueRef(() => ({
     onRealmClick: (id: string) => {
-      dispatch(setDisplayedRealmId(String(id)))
-      dispatch(setRealmPanelVisible(true))
+      if (!realmId) {
+        dispatch(setDisplayedRealmId(String(id)))
+        dispatch(setRealmPanelVisible(true))
 
-      if (assistantVisible("welcome"))
-        updateAssistant({ visible: false, type: "default" })
+        if (assistantVisible("welcome"))
+          updateAssistant({ visible: false, type: "default" })
+      }
     },
   }))
 
   const handleClose = useCallback(() => {
     dispatch(setRealmPanelVisible(false))
+
     const timeout = setTimeout(
       () => dispatch(setDisplayedRealmId(null)),
       REALM_PANEL_ANIMATION_TIME


### PR DESCRIPTION
Resolves #815 

The problem was that when animation was still in progress, user could click on the current realm, which didn't dispatch the event responsible for closing/open the panel