### PR TITLE
Close opened accordion on realm panel close

### DIFF
--- a/src/shared/components/Accordion.tsx
+++ b/src/shared/components/Accordion.tsx
@@ -8,7 +8,7 @@ type AccordionType = "default" | "frame" | "quest" | "panel"
 export type AccordionOutsideActions = {
   openedFromOutside?: boolean
   closeOpenedFromOutside?: () => void
-  additionalTrigger?: boolean // close / open accordion based on another action
+  extraExpand?: boolean // close / open accordion based on another action
 }
 
 export type CommonAccordion = {
@@ -60,7 +60,7 @@ export default function Accordion({
   style,
   isDisabled = false,
   hasInteractiveChildren = false,
-  additionalTrigger,
+  extraExpand,
 }: AccordionProps) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -72,10 +72,10 @@ export default function Accordion({
 
   useEffect(() => {
     // If accordion is opened and there is additional trigger is false, close the accordion
-    if (isOpen && additionalTrigger === false) {
+    if (isOpen && extraExpand === false) {
       setIsOpen(false)
     }
-  }, [isOpen, additionalTrigger])
+  }, [isOpen, extraExpand])
 
   const toggle = () => {
     if (isDisabled) return

--- a/src/shared/components/Accordion.tsx
+++ b/src/shared/components/Accordion.tsx
@@ -8,6 +8,7 @@ type AccordionType = "default" | "frame" | "quest" | "panel"
 export type AccordionOutsideActions = {
   openedFromOutside?: boolean
   closeOpenedFromOutside?: () => void
+  additionalTrigger?: boolean // close / open accordion based on another action
 }
 
 export type CommonAccordion = {
@@ -59,6 +60,7 @@ export default function Accordion({
   style,
   isDisabled = false,
   hasInteractiveChildren = false,
+  additionalTrigger,
 }: AccordionProps) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -67,6 +69,13 @@ export default function Accordion({
       setIsOpen(true)
     }
   }, [openedFromOutside])
+
+  useEffect(() => {
+    // If accordion is opened and there is additional trigger is false, close the accordion
+    if (isOpen && additionalTrigger === false) {
+      setIsOpen(false)
+    }
+  }, [isOpen, additionalTrigger])
 
   const toggle = () => {
     if (isDisabled) return

--- a/src/shared/components/RealmPanel/RealmPanelAccordion/index.tsx
+++ b/src/shared/components/RealmPanel/RealmPanelAccordion/index.tsx
@@ -19,7 +19,7 @@ export default function RealmDetailsAccordion({
       hasInteractiveChildren
       openedFromOutside={openedFromOutside}
       closeOpenedFromOutside={closeOpenedFromOutside}
-      additionalTrigger={realmPanelVisible}
+      extraExpand={realmPanelVisible}
     >
       {children}
     </Accordion>

--- a/src/shared/components/RealmPanel/RealmPanelAccordion/index.tsx
+++ b/src/shared/components/RealmPanel/RealmPanelAccordion/index.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { selectRealmPanelVisible, useDappSelector } from "redux-state"
 import Accordion, { CommonAccordion } from "shared/components/Accordion"
 
 export default function RealmDetailsAccordion({
@@ -8,6 +9,8 @@ export default function RealmDetailsAccordion({
   openedFromOutside,
   closeOpenedFromOutside,
 }: CommonAccordion) {
+  const realmPanelVisible = useDappSelector(selectRealmPanelVisible)
+
   return (
     <Accordion
       title={title}
@@ -16,6 +19,7 @@ export default function RealmDetailsAccordion({
       hasInteractiveChildren
       openedFromOutside={openedFromOutside}
       closeOpenedFromOutside={closeOpenedFromOutside}
+      additionalTrigger={realmPanelVisible}
     >
       {children}
     </Accordion>


### PR DESCRIPTION
Resolves #827 

## What has been done:
Added optional `additionalTrigger` prop to accordion to close the accordion by another defined action

## Testing steps
1. Open realm panel
2. Opened stake/unstake accordion
3. Close realm panel
4. When you open realm panel again, the accordion should be collapsed