### PR TITLE
Handle narrow viewports

### DIFF
--- a/src/shared/components/RealmPanel/RealmDetailsPanel/index.tsx
+++ b/src/shared/components/RealmPanel/RealmDetailsPanel/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react"
-import Panel from "shared/components/Panel"
 import RealmDetailsContent from "./RealmDetailsContent"
 import StakeUnstakeSection from "../RealmPanelAccordion/StakeUnstakeSection"
 import GuardiansSection from "../RealmPanelAccordion/GuardiansSection"
@@ -9,7 +8,7 @@ export default function RealmDetailsPanel() {
     useState(false)
 
   return (
-    <Panel.Container style={{ width: 481 }}>
+    <>
       <RealmDetailsContent
         triggerStakeSectionOpen={() => setStakeSectionOpenedFromOutside(true)}
       />
@@ -18,6 +17,6 @@ export default function RealmDetailsPanel() {
         closeOpenedFromOutside={() => setStakeSectionOpenedFromOutside(false)}
       />
       <GuardiansSection />
-    </Panel.Container>
+    </>
   )
 }

--- a/src/shared/components/RealmPanel/RealmLeaderboardPanel/index.tsx
+++ b/src/shared/components/RealmPanel/RealmLeaderboardPanel/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import Panel from "shared/components/Panel"
 import TabPanel from "shared/components/TabPanel"
+import { useMobileScreen, useTabletScreen } from "shared/hooks"
 import LeaderboardList from "ui/Island/RealmDetails/LeaderboardList"
 import LeaderboardCurrentUser from "ui/Island/RealmDetails/LeaderboardList/LeaderboardCurrentUser"
 
@@ -40,40 +41,36 @@ export default function RealmLeaderboardPanel() {
   const [activeTab, setActiveTab] = useState(2)
 
   return (
-    <Panel.Container position="right">
-      <Panel.Section style={{ padding: 32 }}>
-        <div className="leaderboard_container">
-          <h2 className="header">Leaderboard</h2>
-          {SHOW_LEADERBOARD_SELECTION ? (
-            <TabPanel
-              activeTab={activeTab}
-              setActiveTab={setActiveTab}
-              tabs={[
-                { label: "This week", component: null },
-                { label: "Last week", component: null },
-                {
-                  label: "All time",
-                  component: (
-                    <AllTimeLeaderboard style={{ marginTop: "30px" }} />
-                  ),
-                },
-              ]}
-            />
-          ) : (
-            <AllTimeLeaderboard />
-          )}
-        </div>
-        <style jsx>{`
-          .leaderboard_container {
-            width: 420px;
-          }
-          .header {
-            font: var(--text-h2);
-            font-weight: 500;
-            margin-bottom: 30px;
-          }
-        `}</style>
-      </Panel.Section>
-    </Panel.Container>
+    <Panel.Section style={{ padding: 32 }}>
+      <div className="leaderboard_container">
+        <h2 className="header">Leaderboard</h2>
+        {SHOW_LEADERBOARD_SELECTION ? (
+          <TabPanel
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            tabs={[
+              { label: "This week", component: null },
+              { label: "Last week", component: null },
+              {
+                label: "All time",
+                component: <AllTimeLeaderboard style={{ marginTop: "30px" }} />,
+              },
+            ]}
+          />
+        ) : (
+          <AllTimeLeaderboard />
+        )}
+      </div>
+      <style jsx>{`
+        .leaderboard_container {
+          width: 420px;
+        }
+        .header {
+          font: var(--text-h2);
+          font-weight: 500;
+          margin-bottom: 30px;
+        }
+      `}</style>
+    </Panel.Section>
   )
 }

--- a/src/shared/components/RealmPanel/index.tsx
+++ b/src/shared/components/RealmPanel/index.tsx
@@ -1,13 +1,19 @@
 import React, { useEffect } from "react"
-import { useAssistant, useLocalStorageChange } from "shared/hooks"
+import {
+  useAssistant,
+  useLocalStorageChange,
+  useTabletScreen,
+} from "shared/hooks"
 import { LOCAL_STORAGE_VISITED_REALM } from "shared/constants"
 import RealmDetailsPanel from "./RealmDetailsPanel"
 import RealmLeaderboardPanel from "./RealmLeaderboardPanel"
 import RealmPanelCountdown from "./RealmPanelCountdown"
 import RealmPanelCloseButton from "./RealmPanelCloseButton"
+import Panel from "../Panel"
 
 export default function RealmPanel({ onClose }: { onClose: () => void }) {
   const { updateAssistant } = useAssistant()
+  const isTablet = useTabletScreen()
   const { value, updateStorage } = useLocalStorageChange<boolean>(
     LOCAL_STORAGE_VISITED_REALM
   )
@@ -20,9 +26,16 @@ export default function RealmPanel({ onClose }: { onClose: () => void }) {
 
   return (
     <>
-      <RealmDetailsPanel />
+      <Panel.Container style={{ width: 481 }}>
+        <RealmDetailsPanel />
+        {isTablet && <RealmLeaderboardPanel />}
+      </Panel.Container>
       <RealmPanelCloseButton onClose={onClose} />
-      <RealmLeaderboardPanel />
+      {!isTablet && (
+        <Panel.Container position="right">
+          <RealmLeaderboardPanel />
+        </Panel.Container>
+      )}
       <RealmPanelCountdown />
     </>
   )

--- a/src/shared/constants/game.ts
+++ b/src/shared/constants/game.ts
@@ -1,3 +1,4 @@
 export const WEEKLY_XP_ALLOCATION = 1_000_000
-export const MOBILE_BREAKPOINT = 854 // qHD width
+export const MOBILE_BREAKPOINT = 854
+export const TABLET_BREAKPOINT = 1152
 export const XP_COMING_SOON_TEXT = "XP Drop coming soon"

--- a/src/shared/hooks/helpers.ts
+++ b/src/shared/hooks/helpers.ts
@@ -10,7 +10,7 @@ import {
 import { debounce } from "lodash"
 import { useSpring } from "@react-spring/web"
 import { getWindowDimensions } from "shared/utils"
-import { MOBILE_BREAKPOINT } from "shared/constants"
+import { MOBILE_BREAKPOINT, TABLET_BREAKPOINT } from "shared/constants"
 import { usePostHog } from "posthog-js/react"
 import { useLocation } from "react-router-dom"
 
@@ -230,6 +230,17 @@ export function useLocalStorageChange<T>(key: string): {
   }
 
   return { value, updateStorage }
+}
+
+export function useTabletScreen() {
+  const [width, setWidth] = useState(window.innerWidth)
+
+  useOnResize(() => {
+    const windowSize = getWindowDimensions()
+    setWidth(windowSize.width)
+  })
+
+  return width < TABLET_BREAKPOINT
 }
 
 export function useMobileScreen() {

--- a/src/shared/hooks/realm.ts
+++ b/src/shared/hooks/realm.ts
@@ -3,6 +3,7 @@ import { easings, useSpring } from "@react-spring/web"
 import { useMemo } from "react"
 import { selectRealmPanelVisible, useDappSelector } from "redux-state"
 import { REALM_PANEL_ANIMATION_TIME } from "shared/constants"
+import { useTabletScreen } from "./helpers"
 
 export function useRealmPanelTransition(position: "left" | "right") {
   const realmPanelVisible = useDappSelector(selectRealmPanelVisible)
@@ -43,14 +44,15 @@ export function useRealmPanelTransition(position: "left" | "right") {
 
 export function useRealmCloseButtonTransition() {
   const realmPanelVisible = useDappSelector(selectRealmPanelVisible)
+  const isTablet = useTabletScreen()
 
   const buttonStyles = useMemo(
     () => ({
-      base: { left: "50%", transform: "translateX(-50%)" },
+      base: { left: isTablet ? "75%" : "50%", transform: "translateX(-50%)" },
       visible: { bottom: 160 },
       hidden: { bottom: -50 },
     }),
-    []
+    [isTablet]
   )
 
   const [buttonTransition] = useSpring(() => {
@@ -66,7 +68,7 @@ export function useRealmCloseButtonTransition() {
         easing: easings.easeOutCubic,
       },
     }
-  }, [realmPanelVisible])
+  }, [realmPanelVisible, isTablet])
 
   return buttonTransition
 }

--- a/src/ui/Island/InteractiveIsland.tsx
+++ b/src/ui/Island/InteractiveIsland.tsx
@@ -14,7 +14,12 @@ import {
   selectIslandZoomLevel,
 } from "redux-state/selectors/island"
 import { ISLAND_BOX, getRealmPosition } from "shared/constants"
-import { useValueRef, useBeforeFirstPaint, useOnResize } from "shared/hooks"
+import {
+  useValueRef,
+  useBeforeFirstPaint,
+  useOnResize,
+  useTabletScreen,
+} from "shared/hooks"
 import {
   getWindowDimensions,
   getMinimumScale,
@@ -30,6 +35,7 @@ import AttackLine from "./IslandRealmsDetails/AttackLine"
 function InteractiveIsland() {
   const selectedRealmId = useDappSelector(selectDisplayedRealmId)
   const selectedRealmPanelVisible = useDappSelector(selectRealmPanelVisible)
+  const isTablet = useTabletScreen()
   const settingsRef = useRef({ minScale: 0 })
   const [stageBounds, setStageDimensions] = useState(() =>
     getWindowDimensions()
@@ -170,7 +176,9 @@ function InteractiveIsland() {
 
       if (selectedRealmId && selectedRealmPanelVisible) {
         const { x, y, width, height } = getRealmPosition(selectedRealmId)
-        const newPosX = stageWidth / 2 - (x + width / 2) * stageScaleX
+        const newPosX = isTablet
+          ? stageWidth / 1.33 - (x + width / 2) * stageScaleX
+          : stageWidth / 2 - (x + width / 2) * stageScaleX
         const newPosY = stageHeight / 2 - (y + height / 2) * stageScaleY
 
         stage?.to({ x: newPosX, y: newPosY })
@@ -185,7 +193,7 @@ function InteractiveIsland() {
         })
       }
     }
-  }, [selectedRealmId, selectedRealmPanelVisible, stageBounds])
+  }, [selectedRealmId, selectedRealmPanelVisible, stageBounds, isTablet])
 
   return (
     <>


### PR DESCRIPTION
Resolves: #743 
On the minimum supported screen we should be able to see the panels' UI and the realm in the background

- [ ] When the user is visiting the website from mobile - make sure there are no regressions
- [ ] Make sure the minimum viewport width displays the realm panels properly
- [ ] The Leaderboard panel should be moved to the left side, below the realm panel when the viewport becomes too narrow

 <img width="934" alt="Screenshot 2023-12-05 at 20 28 26" src="https://github.com/tahowallet/dapp/assets/28560653/379ccd52-9638-46f0-9a51-165c2c7dc82d">

