### PR TITLE
Change map background on realm focus

### DIFF
--- a/src/shared/components/RealmPanel/RealmPanelCountdown.tsx
+++ b/src/shared/components/RealmPanel/RealmPanelCountdown.tsx
@@ -31,7 +31,7 @@ export default function RealmPanelCountdown() {
       <style jsx>{`
         .countdown {
           position: absolute;
-          textalign: right;
+          text-align: right;
           top: 104px;
           right: 32px;
         }

--- a/src/ui/Background/BackgroundOverlay.tsx
+++ b/src/ui/Background/BackgroundOverlay.tsx
@@ -1,0 +1,36 @@
+import { easings, useSpring } from "@react-spring/web"
+import React from "react"
+import { animated } from "@react-spring/konva"
+import { selectRealmPanelVisible, useDappSelector } from "redux-state"
+import { ISLAND_BOX, REALM_PANEL_ANIMATION_TIME } from "shared/constants"
+
+export default function BackgroundOverlay() {
+  const realmPanelVisible = useDappSelector(selectRealmPanelVisible)
+
+  const [overlayProps] = useSpring(() => {
+    const destinationOverlayProps = realmPanelVisible
+      ? { opacity: 1 }
+      : { opacity: 0 }
+
+    return {
+      from: { opacity: 0 },
+      to: destinationOverlayProps,
+      config: {
+        duration: REALM_PANEL_ANIMATION_TIME,
+        easing: easings.easeInOutCubic,
+      },
+    }
+  }, [realmPanelVisible])
+
+  return (
+    // @ts-expect-error FIXME: @react-spring-types
+    <animated.Rect
+      fill="#354241"
+      width={ISLAND_BOX.width}
+      height={ISLAND_BOX.height}
+      globalCompositeOperation="color"
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...overlayProps}
+    />
+  )
+}

--- a/src/ui/GlobalStyles/index.tsx
+++ b/src/ui/GlobalStyles/index.tsx
@@ -183,6 +183,10 @@ export default function GlobalStyles() {
           font-size: 16px;
         }
 
+        body.overlay {
+          background: #1c2928;
+        }
+
         p,
         span,
         div,

--- a/src/ui/Island/Background.tsx
+++ b/src/ui/Island/Background.tsx
@@ -11,10 +11,16 @@ import { Easings } from "konva/lib/Tween"
 import useImage from "use-image"
 
 import backgroundImg from "public/dapp_island_bg_bw.webp"
-import { ISLAND_BOX, REALMS_MAP_DATA } from "shared/constants"
-import { usePrevious, useBeforeFirstPaint } from "shared/hooks"
+import {
+  ISLAND_BOX,
+  REALMS_MAP_DATA,
+  REALM_PANEL_ANIMATION_TIME,
+} from "shared/constants"
+import { usePrevious, useBeforeFirstPaint, useTimeout } from "shared/hooks"
 import { createBackgroundMask } from "shared/utils"
 import { OverlayType } from "shared/types"
+import BackgroundOverlay from "ui/Background/BackgroundOverlay"
+import { selectRealmPanelVisible, useDappSelector } from "redux-state"
 
 const getOverlay = (overlay: OverlayType) => {
   if (overlay === "dark") {
@@ -101,6 +107,22 @@ export default function Background({ overlay }: { overlay: OverlayType }) {
   //   }
   // }, [isMounted, overlay, previousOverlay])
 
+  const realmPanelVisible = useDappSelector(selectRealmPanelVisible)
+
+  // Handles extended canvas background color change
+  useEffect(() => {
+    if (realmPanelVisible) {
+      return document.body.classList.add("overlay")
+    }
+
+    const timeout = setTimeout(
+      () => document.body.classList.remove("overlay"),
+      REALM_PANEL_ANIMATION_TIME
+    )
+
+    return () => clearTimeout(timeout)
+  }, [realmPanelVisible])
+
   const mask = useMemo(() => {
     if (!islandImage) {
       return undefined
@@ -111,7 +133,12 @@ export default function Background({ overlay }: { overlay: OverlayType }) {
 
   return (
     <Group listening={false}>
-      <KonvaImage image={mask} />
+      <KonvaImage
+        image={mask}
+        stroke="#1c2928"
+        strokeWidth={realmPanelVisible ? 5 : 0}
+      />
+      <BackgroundOverlay />
       {/* <Group ref={overlayRef}>{currentOverlay}</Group> */}
     </Group>
   )

--- a/src/ui/Island/IslandRealmsDetails/AttackLine.tsx
+++ b/src/ui/Island/IslandRealmsDetails/AttackLine.tsx
@@ -1,11 +1,15 @@
 import React from "react"
 import { Image } from "react-konva"
+import { selectRealmPanelVisible, useDappSelector } from "redux-state"
 import attackLineImg from "shared/assets/attack-line.svg"
 import { FIGMA_FACTOR } from "shared/constants"
 import useImage from "use-image"
 
-export default function VampireChallenge() {
+export default function AttackLine() {
   const [attackLine] = useImage(attackLineImg)
+  const realmPanelVisible = useDappSelector(selectRealmPanelVisible)
+
+  if (realmPanelVisible) return null
 
   return (
     <Image


### PR DESCRIPTION
Resolves #837 

## What has been done:
- Added map overlay when realm is focused
- Removed attack line when realm is focused

![Zrzut ekranu 2023-12-6 o 13 46 38](https://github.com/tahowallet/dapp/assets/73061939/6a0f67cb-17ba-44f6-82f9-0f84d99e74cf)
![Zrzut ekranu 2023-12-6 o 13 46 32](https://github.com/tahowallet/dapp/assets/73061939/db4f00f9-4ae0-42e9-997f-193f85aadd30)
