### PR TITLE
Update empty leaderboard placeholder date

### DIFF
--- a/src/ui/Island/RealmDetails/LeaderboardList/index.tsx
+++ b/src/ui/Island/RealmDetails/LeaderboardList/index.tsx
@@ -9,7 +9,7 @@ import {
 import LeaderboardItem from "./LeaderboardItem"
 import RealmDetailsPlaceholder from "../Placeholder"
 
-const leaderboardDateAvailable = "Nov 30"
+const leaderboardDateAvailable = "Dec 14"
 
 export default function LeaderboardList() {
   const realmId = useDappSelector(selectDisplayedRealmId)


### PR DESCRIPTION
### What

We need to update the leaderboard placeholder date as zkSync realm will be empty for a week.
 
![image](https://github.com/tahowallet/dapp/assets/20949277/296f5c11-81b6-4ad5-922a-ae04bcdbb22f)
