### PR TITLE
Add pageleave event tracking

### DIFF
--- a/src/shared/hooks/helpers.ts
+++ b/src/shared/hooks/helpers.ts
@@ -254,6 +254,20 @@ export function useMobileScreen() {
   return width < MOBILE_BREAKPOINT
 }
 
+export function useUnLoad() {
+  const posthog = usePostHog()
+
+  useEffect(() => {
+    const onUnload = () => {
+      posthog?.capture("$pageleave")
+    }
+    window.addEventListener("beforeunload", onUnload)
+    return () => {
+      window.removeEventListener("beforeunload", onUnload)
+    }
+  }, [posthog])
+}
+
 export function useTrackEvents() {
   const location = useLocation()
   const posthog = usePostHog()

--- a/src/ui/DApps/index.tsx
+++ b/src/ui/DApps/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { useMobileScreen, useTrackEvents } from "shared/hooks"
+import { useMobileScreen, useTrackEvents, useUnLoad } from "shared/hooks"
 import GlobalStyles from "ui/GlobalStyles"
 import MobileDApp from "./MobileDApp"
 import DesktopDApp from "./DesktopDApp"
@@ -7,6 +7,7 @@ import DesktopDApp from "./DesktopDApp"
 export default function DApp() {
   const isMobileScreen = useMobileScreen()
   useTrackEvents()
+  useUnLoad()
 
   return (
     <>


### PR DESCRIPTION
Resolves: #696 

How to test:
1. Open Dapp 
2. Close window

On events list in PostHog service  you should find `pageleave` event:


<img width="1424" alt="Screenshot 2023-12-08 at 09 44 28" src="https://github.com/tahowallet/dapp/assets/28560653/c2a9f175-4da3-40a3-8124-9ccf60a09525">
