### PR TITLE
Fix assistant messaging

### DIFF
--- a/src/shared/hooks/assistant.ts
+++ b/src/shared/hooks/assistant.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { LOCAL_STORAGE_ASSISTANT } from "shared/constants"
 import { selectStakingRealmId, useDappSelector } from "redux-state"
 import { useLocalStorageChange } from "./helpers"
@@ -17,15 +18,30 @@ export function useAssistant(): {
 } {
   const isStakedInRealm = useDappSelector(selectStakingRealmId)
 
-  const { value, updateStorage } = useLocalStorageChange<Assistant>(
-    LOCAL_STORAGE_ASSISTANT
-  )
+  const { value: assistantState, updateStorage: updateAssistantState } =
+    useLocalStorageChange<Assistant>(LOCAL_STORAGE_ASSISTANT)
+
+  useEffect(() => {
+    if (!assistantState) {
+      if (!isStakedInRealm) {
+        updateAssistantState({ visible: true, type: "welcome" })
+      } else {
+        updateAssistantState({ visible: false, type: "default" })
+      }
+    }
+  }, [assistantState, updateAssistantState, isStakedInRealm])
 
   const assistantVisible = (type: AssistantType): boolean => {
     if ((type === "welcome" || type === "first-realm") && isStakedInRealm)
       return false
-    return value ? value.visible && value.type === type : false
+    return assistantState
+      ? assistantState.visible && assistantState.type === type
+      : false
   }
 
-  return { assistant: value, updateAssistant: updateStorage, assistantVisible }
+  return {
+    assistant: assistantState,
+    updateAssistant: updateAssistantState,
+    assistantVisible,
+  }
 }

--- a/src/shared/hooks/realm.ts
+++ b/src/shared/hooks/realm.ts
@@ -108,20 +108,30 @@ export function useOnRealmClick() {
   const { value: visitedRealm, updateStorage: updateVisitedRealm } =
     useLocalStorageChange<boolean>(LOCAL_STORAGE_VISITED_REALM)
 
-  const onRealmClick = (id: string) => {
-    if (!realmId) {
-      dispatch(setDisplayedRealmId(String(id)))
-      dispatch(setRealmPanelVisible(true))
+  const onRealmClick = useCallback(
+    (id: string) => {
+      if (!realmId) {
+        dispatch(setDisplayedRealmId(String(id)))
+        dispatch(setRealmPanelVisible(true))
 
-      if (assistantVisible("welcome"))
-        updateAssistant({ visible: false, type: "default" })
+        if (assistantVisible("welcome"))
+          updateAssistant({ visible: false, type: "default" })
 
-      if (!visitedRealm) {
-        updateVisitedRealm(true)
-        updateAssistant({ visible: true, type: "first-realm" })
+        if (!visitedRealm) {
+          updateVisitedRealm(true)
+          updateAssistant({ visible: true, type: "first-realm" })
+        }
       }
-    }
-  }
+    },
+    [
+      assistantVisible,
+      dispatch,
+      realmId,
+      updateAssistant,
+      updateVisitedRealm,
+      visitedRealm,
+    ]
+  )
 
   return onRealmClick
 }

--- a/src/shared/hooks/realm.ts
+++ b/src/shared/hooks/realm.ts
@@ -1,14 +1,19 @@
 import { easings, useSpring } from "@react-spring/web"
 import { useCallback, useMemo } from "react"
 import {
+  selectDisplayedRealmId,
   selectRealmPanelVisible,
   setDisplayedRealmId,
   setRealmPanelVisible,
   useDappDispatch,
   useDappSelector,
 } from "redux-state"
-import { REALM_PANEL_ANIMATION_TIME } from "shared/constants"
-import { useTabletScreen } from "./helpers"
+import {
+  LOCAL_STORAGE_VISITED_REALM,
+  REALM_PANEL_ANIMATION_TIME,
+} from "shared/constants"
+import { useLocalStorageChange, useTabletScreen } from "./helpers"
+import { useAssistant } from "./assistant"
 
 export function useRealmPanelTransition(position: "left" | "right") {
   const realmPanelVisible = useDappSelector(selectRealmPanelVisible)
@@ -93,4 +98,30 @@ export function usePanelRealmClose() {
   }, [dispatch])
 
   return handlePanelClose
+}
+
+export function useOnRealmClick() {
+  const realmId = useDappSelector(selectDisplayedRealmId)
+  const dispatch = useDappDispatch()
+  const { updateAssistant, assistantVisible } = useAssistant()
+
+  const { value: visitedRealm, updateStorage: updateVisitedRealm } =
+    useLocalStorageChange<boolean>(LOCAL_STORAGE_VISITED_REALM)
+
+  const onRealmClick = (id: string) => {
+    if (!realmId) {
+      dispatch(setDisplayedRealmId(String(id)))
+      dispatch(setRealmPanelVisible(true))
+
+      if (assistantVisible("welcome"))
+        updateAssistant({ visible: false, type: "default" })
+
+      if (!visitedRealm) {
+        updateVisitedRealm(true)
+        updateAssistant({ visible: true, type: "first-realm" })
+      }
+    }
+  }
+
+  return onRealmClick
 }

--- a/src/ui/Assistant/index.tsx
+++ b/src/ui/Assistant/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React from "react"
 import Icon from "shared/components/Media/Icon"
 import assistantImage from "shared/assets/assistant.png"
 import Portal from "shared/components/Interface/Portal"
@@ -10,10 +10,6 @@ import AssistantFirstRealm from "./AssistantContent/AssistantFirstRealm"
 
 export default function Assistant() {
   const { assistant, updateAssistant } = useAssistant()
-
-  useEffect(() => {
-    if (!assistant) updateAssistant({ visible: true, type: "welcome" })
-  }, [assistant, updateAssistant])
 
   if (!assistant) return null
 

--- a/src/ui/Island/RealmPanel/index.tsx
+++ b/src/ui/Island/RealmPanel/index.tsx
@@ -2,11 +2,11 @@ import React from "react"
 import { usePanelRealmClose, useTabletScreen } from "shared/hooks"
 import { selectRealmPanelVisible, useDappSelector } from "redux-state"
 import ClickableModalOverlay from "shared/components/Dialogs/ClickableModalOverlay"
+import Panel from "shared/components/Dialogs/Panel"
 import RealmDetailsPanel from "./RealmDetailsPanel"
 import RealmLeaderboardPanel from "./RealmLeaderboardPanel"
 import RealmPanelCountdown from "./RealmPanelCountdown"
 import RealmPanelCloseButton from "./RealmPanelCloseButton"
-import Panel from "../../../shared/components/Dialogs/Panel"
 
 export default function RealmPanel({ onClose }: { onClose: () => void }) {
   const isTablet = useTabletScreen()

--- a/src/ui/Island/RealmPanel/index.tsx
+++ b/src/ui/Island/RealmPanel/index.tsx
@@ -1,11 +1,5 @@
-import React, { useEffect } from "react"
-import {
-  useAssistant,
-  useLocalStorageChange,
-  usePanelRealmClose,
-  useTabletScreen,
-} from "shared/hooks"
-import { LOCAL_STORAGE_VISITED_REALM } from "shared/constants"
+import React from "react"
+import { usePanelRealmClose, useTabletScreen } from "shared/hooks"
 import { selectRealmPanelVisible, useDappSelector } from "redux-state"
 import ClickableModalOverlay from "shared/components/Dialogs/ClickableModalOverlay"
 import RealmDetailsPanel from "./RealmDetailsPanel"
@@ -15,20 +9,9 @@ import RealmPanelCloseButton from "./RealmPanelCloseButton"
 import Panel from "../../../shared/components/Dialogs/Panel"
 
 export default function RealmPanel({ onClose }: { onClose: () => void }) {
-  const { updateAssistant } = useAssistant()
   const isTablet = useTabletScreen()
-  const { value, updateStorage } = useLocalStorageChange<boolean>(
-    LOCAL_STORAGE_VISITED_REALM
-  )
-
   const realmPanelVisible = useDappSelector(selectRealmPanelVisible)
   const handlePanelClose = usePanelRealmClose()
-
-  useEffect(() => {
-    if (value) return
-    updateStorage(true)
-    updateAssistant({ visible: true, type: "first-realm" })
-  }, [value, updateStorage, updateAssistant])
 
   return (
     <>

--- a/src/ui/Island/index.tsx
+++ b/src/ui/Island/index.tsx
@@ -3,16 +3,13 @@ import backgroundImg from "public/dapp_island_bg.webp"
 import {
   useValueRef,
   IslandContext,
-  useAssistant,
   useAssets,
   usePanelRealmClose,
+  useOnRealmClick,
 } from "shared/hooks"
 import {
   selectDisplayedRealmId,
   selectRealmNameById,
-  setDisplayedRealmId,
-  setRealmPanelVisible,
-  useDappDispatch,
   useDappSelector,
 } from "redux-state"
 import FullPageLoader from "shared/components/Loaders/FullPageLoader"
@@ -28,11 +25,9 @@ function IslandWrapper() {
     selectRealmNameById(state, realmId)
   )
 
-  const dispatch = useDappDispatch()
-
-  const { updateAssistant, assistantVisible } = useAssistant()
-
   const posthog = usePostHog()
+  const onRealmClick = useOnRealmClick()
+  const handlePanelClose = usePanelRealmClose()
 
   useEffect(() => {
     if (realmName) {
@@ -40,19 +35,7 @@ function IslandWrapper() {
     }
   }, [posthog, realmName])
 
-  const contextRef = useValueRef(() => ({
-    onRealmClick: (id: string) => {
-      if (!realmId) {
-        dispatch(setDisplayedRealmId(String(id)))
-        dispatch(setRealmPanelVisible(true))
-
-        if (assistantVisible("welcome"))
-          updateAssistant({ visible: false, type: "default" })
-      }
-    },
-  }))
-
-  const handlePanelClose = usePanelRealmClose()
+  const contextRef = useValueRef(() => ({ onRealmClick }))
 
   return (
     <>


### PR DESCRIPTION
Resolves #866 

## What has been done
Messages from assistant were not displayed correctly due to unnecessary `useEffect`. Also extracted some `Island` logic to `useOnRealmClick` hook.

## Testing
- [x] Clear `localStorage`
- [x] Connect wallet that is not staked in any realm
- [x] After entering portal, `Welcome to Subscape, Nomad` message appears
- [x] After clicking on realm for first time, `Why join a realm` message appears 