### PR TITLE
Change current week on beta close

### DIFF
--- a/src/ui/Island/RealmPanel/RealmPanelCountdown.tsx
+++ b/src/ui/Island/RealmPanel/RealmPanelCountdown.tsx
@@ -34,7 +34,10 @@ export default function RealmPanelCountdown() {
         )}
         <div className="column">
           <div className="week">
-            Week {seasonWeek}{" "}
+            Week{" "}
+            {process.env.IS_BETA_CLOSED === "true"
+              ? seasonDuration
+              : seasonWeek}{" "}
             <span style={{ fontSize: 16, color: "var(--secondary-s1-50)" }}>
               / {seasonDuration}
             </span>


### PR DESCRIPTION
## What has been done

Week counter went above season duration, changed to be 7/7

## Testing

- [ ] Set `BETA_IS_CLOSED` flag to `true` - current week is 7/7

## Screenshots / images / videos

![Zrzut ekranu 2023-12-14 o 10 15 54](https://github.com/tahowallet/dapp/assets/73061939/0c2123c4-49ac-4eb2-a9c1-c494fc128e48)
